### PR TITLE
Adds missing MacOS filesystem DS_Store ignore to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+.DS_Store


### PR DESCRIPTION
Simple PR that prevents those stupid MacOS `.DS_Store` files from being committed. I don't know how I haven't noticed this issue until now.