### PR TITLE
Updates links from the conda-incubator GH org to conda

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Syntax for this file at https://help.github.com/articles/about-codeowners/
 
-*   @conda-incubator/builds-tools
+*   @conda/builds-tools

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Overview
-This repository contains data used in integration (and other) tests for the [conda-recipe-manager](https://github.com/conda-incubator/conda-recipe-manager) project.
+This repository contains data used in integration (and other) tests for the [conda-recipe-manager](https://github.com/conda/conda-recipe-manager) project.
 
 This is a significantly large repository of data, so be aware when cloning it.


### PR DESCRIPTION
Sister PR to https://github.com/conda/conda-recipe-manager/pull/330 that updates references from `conda-incubator` to `conda`